### PR TITLE
Update amp-wp-app-shell.js

### DIFF
--- a/assets/js/amp-wp-app-shell.js
+++ b/assets/js/amp-wp-app-shell.js
@@ -112,6 +112,9 @@
 	 */
 	function isHeaderVisible() {
 		const element = document.querySelector( '.site-branding' );
+		if ( ! element ) { 
+			return;
+		} 
 		const clientRect = element.getBoundingClientRect();
 		return clientRect.height + clientRect.top >= 0;
 	}
@@ -124,7 +127,8 @@
 	 */
 	function fetchShadowDocResponse( url ) {
 		const ampUrl = new URL( url );
-		ampUrl.searchParams.set( ampAppShell.componentQueryVar, 'inner' );
+		const pathSuffix = '_' + ampAppShell.componentQueryVar + '_inner';
+		ampUrl.pathname = ampUrl.pathname + pathSuffix;
 
 		return fetch( ampUrl.toString(), {
 			method: 'GET',


### PR DESCRIPTION
**Rationale**
Due to caching restrictions with WPengine the use of a query-string parameter to
denote an inner shell request is problematic as it prevents the request from
being cached independently. The request needs to be distinctly different from
the outer shell in-order for it to be treated as a seperate cache item.

**Changes**

- Query string parameter is now appended to the path instead of
- Fixed bug where code was always expecting a .site-branding element to exist