### PR TITLE
Ensure .site-content-contain element exists

### DIFF
--- a/assets/js/amp-wp-app-shell.js
+++ b/assets/js/amp-wp-app-shell.js
@@ -240,8 +240,14 @@
 					}
 
 					if ( scrollIntoView && ! isHeaderVisible() ) {
+						const siteContent = document.querySelector( '.site-content-contain' );
+
+						if ( ! siteContent ) {
+							return;
+						}
+
 						// @todo The scroll position is not correct when admin bar is used. Consider scrolling to Y coordinate smoothly instead.
-						document.querySelector( '.site-content-contain' ).scrollIntoView( {
+						siteContent.scrollIntoView( {
 							block: 'start',
 							inline: 'start',
 							behavior: 'smooth'


### PR DESCRIPTION
**Rationale**
A prior change introduced an early return for `isHeaderVisible` should the
`site-branding` element not be found in the document. However this early
return caused code to trigger elsewhere related to scrolling.

**Changes**

- Ensure `.site-content-contain` document lookup is also guarded to prevent
  calling scrollIntoView on a non-existing dom element.